### PR TITLE
Change Hijack button from GET to POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ INSTALLED_APPS = (
 )
 ```
 
-For the admin integration to work, you must explicitly set `HIJACK_ALLOW_GET_REQUESTS = True` in your project settings.
-Please be aware that users can now be hijacked not only using POST requests, but also using GET requests, which could facilitate CSRF attacks.
-
 ## Configuration
 
 ### `HIJACK_BUTTON_TEMPLATE`

--- a/hijack_admin/admin.py
+++ b/hijack_admin/admin.py
@@ -18,6 +18,10 @@ except ImportError:
 
 class HijackUserAdminMixin(object):
 
+    def changelist_view(self, request, *args, **kwargs):
+        self.__request = request
+        return super().changelist_view(request, *args, **kwargs)
+
     def hijack_field(self, obj):
         hijack_attributes = hijack_settings.HIJACK_URL_ALLOWED_ATTRIBUTES
 
@@ -34,7 +38,7 @@ class HijackUserAdminMixin(object):
             'username': str(obj),
         }
 
-        return button_template.render(button_context)
+        return button_template.render(button_context, request=self.__request)
 
     hijack_field.short_description = _('Hijack user')
 

--- a/hijack_admin/checks.py
+++ b/hijack_admin/checks.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.core.checks import Error, Warning, register
+from django.core.checks import Warning, register
 from django.conf.global_settings import AUTH_USER_MODEL as DEFAULT_AUTH_USER_MODEL
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_user_model
-
-from hijack import settings as hijack_settings
 
 
 def _using_hijack_admin_mixin():
@@ -18,20 +16,6 @@ def _using_hijack_admin_mixin():
             admin.site._registry.get(get_user_model(), None))
 
     return issubclass(user_admin_class, HijackUserAdminMixin)
-
-
-def check_get_requests_allowed(app_configs, **kwargs):
-    errors = []
-    if not hijack_settings.HIJACK_ALLOW_GET_REQUESTS:
-        errors.append(
-            Error(
-                'Hijack GET requests must be allowed for django-hijack-admin to work.',
-                hint='Set HIJACK_ALLOW_GET_REQUESTS to True.',
-                obj=None,
-                id='hijack_admin.E001',
-            )
-        )
-    return errors
 
 
 def check_custom_user_model(app_configs, **kwargs):
@@ -51,7 +35,6 @@ def check_custom_user_model(app_configs, **kwargs):
 
 def register_checks():
     for check in [
-        check_get_requests_allowed,
         check_custom_user_model,
     ]:
         register(check)

--- a/hijack_admin/templates/hijack_admin/admin_button.html
+++ b/hijack_admin/templates/hijack_admin/admin_button.html
@@ -1,5 +1,9 @@
 {% load i18n %}
 
-<a href="{{ hijack_url }}" class="button">
-    {% blocktrans %}Hijack {{ username }}{% endblocktrans %}
-</a>
+<form action="{{ hijack_url }}" method="post">
+    {% csrf_token %}
+    <button type="submit" class="button">
+	    {% blocktrans %}Hijack {{ username }}{% endblocktrans %}
+    </button>
+</form>
+

--- a/hijack_admin/tests/test_checks.py
+++ b/hijack_admin/tests/test_checks.py
@@ -4,39 +4,18 @@ import django
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from hijack_admin.admin import HijackUserAdmin
-from hijack.tests.utils import SettingsOverride
 
 if django.VERSION < (1, 7):
     pass
 else:
     from django.conf import settings
-    from django.core.checks import Error, Warning
+    from django.core.checks import Warning
     from django.test import TestCase, override_settings
-
-    from hijack import settings as hijack_settings
 
     from hijack_admin import checks
     from hijack_admin.apps import HijackAdminConfig
 
     class ChecksTests(TestCase):
-
-        def test_check_get_requests_allowed(self):
-
-            self.assertTrue(hijack_settings.HIJACK_ALLOW_GET_REQUESTS)
-            errors = checks.check_get_requests_allowed(HijackAdminConfig)
-            self.assertFalse(errors)
-
-            with SettingsOverride(hijack_settings, HIJACK_ALLOW_GET_REQUESTS=False):
-                errors = checks.check_get_requests_allowed(HijackAdminConfig)
-                expected_errors = [
-                    Error(
-                        'Hijack GET requests must be allowed for django-hijack-admin to work.',
-                        hint='Set HIJACK_ALLOW_GET_REQUESTS to True.',
-                        obj=None,
-                        id='hijack_admin.E001',
-                    )
-                ]
-                self.assertEqual(errors, expected_errors)
 
         def test_check_default_user_model(self):
             warnings = checks.check_custom_user_model(HijackAdminConfig)

--- a/hijack_admin/tests/test_settings.py
+++ b/hijack_admin/tests/test_settings.py
@@ -102,5 +102,3 @@ SECRET_KEY = 'foobar'
 LANGUAGE_CODE = 'en-us'
 USE_I18N = True
 USE_L10N = True
-
-HIJACK_ALLOW_GET_REQUESTS = True


### PR DESCRIPTION
Hey,

I did a quick change in my fork to use POST instead of GET in admin, thereby avoiding the CSRF risks you mention in the README.

If I'm missing anything obvious why it should not be done this way, please let me know.